### PR TITLE
Add removeRange API to DbProvider

### DIFF
--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -98,6 +98,8 @@ export abstract class DbIndexFTSFromRangeQueries implements DbIndex {
         : Promise<ItemType[]>;
     abstract getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
         reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): Promise<ItemType[]>;
+    abstract getKeysForRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
+        : Promise<any[]>;
     abstract countAll(): Promise<number>;
     abstract countOnly(key: KeyType): Promise<number>;
     abstract countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)

--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -102,6 +102,4 @@ export abstract class DbIndexFTSFromRangeQueries implements DbIndex {
     abstract countOnly(key: KeyType): Promise<number>;
     abstract countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
         : Promise<number>;
-    abstract removeRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
-        : Promise<void>;
 }

--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -102,4 +102,6 @@ export abstract class DbIndexFTSFromRangeQueries implements DbIndex {
     abstract countOnly(key: KeyType): Promise<number>;
     abstract countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
         : Promise<number>;
+    abstract removeRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
+        : Promise<void>;
 }

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -54,7 +54,7 @@ export class InMemoryProvider extends DbProvider {
 
     internal_getStore(name: string): StoreData {
         return this._stores[name];
-    }           
+    }
 }
 
 // Notes: Doesn't limit the stores it can fetch to those in the stores it was "created" with, nor does it handle read-only transactions
@@ -223,14 +223,11 @@ class InMemoryStore implements DbStore {
             return Promise.reject(joinedKeys);
         }
 
-        return this.removeEx(joinedKeys);
+        return this.removeInternal(joinedKeys);
     }
 
-    removeRange(indexName: string, 
-                keyLowRange: KeyType, 
-                keyHighRange: KeyType, 
-                lowRangeExclusive?: boolean, 
-                highRangeExclusive?: boolean): Promise<void> {
+    removeRange(indexName: string, keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
+        : Promise<void> {
 
         if (!this._trans.internal_isOpen()) {
             return Promise.reject<void>('InMemoryTransaction already closed');
@@ -241,8 +238,8 @@ class InMemoryStore implements DbStore {
         if (!index || isError(index)) {
             return Promise.reject<void>('Index "' + indexName + '" not found');
         }            
-        return (index as InMemoryIndex).getKeysForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive).then(keys => {
-            return this.removeEx(keys);
+        return index.getKeysForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive).then(keys => {
+            return this.removeInternal(keys);
         });
     }     
 
@@ -273,7 +270,7 @@ class InMemoryStore implements DbStore {
         return Promise.resolve<void>(void 0);
     }
 
-    private removeEx(keys: string[]): Promise<void> {
+    private removeInternal(keys: string[]): Promise<void> {
         if (!this._trans.internal_isOpen()) {
             return Promise.reject<void>('InMemoryTransaction already closed');
         }
@@ -371,6 +368,21 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
         return this._returnResultsFromKeys(data!!!, sortedKeys!!!, reverseOrSortOrder, limit, offset);
     }
 
+    getKeysForRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
+        : Promise<any[]> {
+        if (!this._trans.internal_isOpen()) {
+            return Promise.reject('InMemoryTransaction already closed');
+        }
+        const keys = attempt(() => {
+            const data = this._calcChunkedData();
+            return this._getKeysForRange(data, keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+        });
+        if (isError(keys)) {
+            return Promise.reject(void 0);
+        }
+        return Promise.resolve(keys);
+    }
+
     // Warning: This function can throw, make sure to trap.
     private _getKeysForRange(data: Dictionary<ItemType[]>|Dictionary<ItemType>, keyLowRange: KeyType, keyHighRange: KeyType,
             lowRangeExclusive?: boolean, highRangeExclusive?: boolean): string[] {
@@ -430,22 +442,5 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
         }
 
         return Promise.resolve(keys.length);
-    }
-
-    public getKeysForRange(keyLowRange: KeyType, 
-                           keyHighRange: KeyType, 
-                           lowRangeExclusive?: boolean, 
-                           highRangeExclusive?: boolean): Promise<string[]> {
-        if (!this._trans.internal_isOpen()) {
-            return Promise.reject('InMemoryTransaction already closed');
-        }
-        const keys = attempt(() => {
-            const data = this._calcChunkedData();
-            return this._getKeysForRange(data, keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
-        });
-        if (isError(keys)) {
-            return Promise.reject(void 0);
-        }
-        return Promise.resolve(keys);
     }
 }

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -815,6 +815,19 @@ class IndexedDbIndex extends DbIndexFTSFromRangeQueries {
         return this._countRequest(req);
     }
 
+    removeRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean): Promise<void> {
+        const keyRange = attempt(() => {
+            return this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+        });
+        if (isError(keyRange)) {
+            return Promise.reject(keyRange);
+        }
+        let req = this._store.openCursor(keyRange, 'next');
+        return IndexedDbIndex.iterateOverCursorRequest(req, cursor => {
+          cursor.delete();
+        });
+      }    
+
     static getFromCursorRequest<T>(req: IDBRequest, limit?: number, offset?: number): Promise<T[]> {
         let outList: T[] = [];
         return this.iterateOverCursorRequest(req, cursor => {

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -840,9 +840,7 @@ class IndexedDbIndex extends DbIndexFTSFromRangeQueries {
             return Promise.reject<string[]>(keyRange);
         }
         if (this._store.getAllKeys && !this._fakeComplicatedKeys) {
-            return IndexedDbProvider.WrapRequest<any[]>(this._store.getAllKeys(keyRange)).then(keys => {
-                return keys;
-            });
+            return IndexedDbProvider.WrapRequest<any[]>(this._store.getAllKeys(keyRange));
         }
 
         let keys: any[] = [];

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -63,6 +63,7 @@ export interface DbIndex {
     getOnly(key: KeyType, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): Promise<ItemType[]>;
     getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
         reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): Promise<ItemType[]>;
+    getKeysForRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean): Promise<any[]>;
     countAll(): Promise<number>;
     countOnly(key: KeyType): Promise<number>;
     countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -68,6 +68,7 @@ export interface DbIndex {
     countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
         : Promise<number>;
     fullTextSearch(searchPhrase: string, resolution?: FullTextTermResolution, limit?: number): Promise<ItemType[]>;
+    removeRange( keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean): Promise<void>;
 }
 
 // Interface type describing a database store opened for accessing.  Get commands at this level work against the primary keypath
@@ -181,7 +182,18 @@ export abstract class DbProvider {
         });
     }
 
-    private _getStoreIndexTransaction(storeName: string, readWrite: boolean, indexName: string | undefined): Promise<DbIndex> {
+    removeRange(storeName: string,
+                indexName: string,
+                keyLowRange: KeyType,
+                keyHighRange: KeyType,
+                lowRangeExclusive?: boolean,
+                highRangeExclusive?: boolean): Promise<void> {
+      return this._getStoreIndexTransaction(storeName, true, indexName).then( index => {
+        return index.removeRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+      });
+    }    
+
+    protected _getStoreIndexTransaction(storeName: string, readWrite: boolean, indexName: string | undefined): Promise<DbIndex> {
         return this._getStoreTransaction(storeName, readWrite).then(store => {
             const index = attempt(() => {
                 return indexName ? store.openIndex(indexName) : store.openPrimaryKey();

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -145,7 +145,7 @@ export abstract class DbProvider {
 
     protected abstract _deleteDatabaseInternal(): Promise<void>;
 
-    private _getStoreTransaction(storeName: string, readWrite: boolean): Promise<DbStore> {
+    protected _getStoreTransaction(storeName: string, readWrite: boolean): Promise<DbStore> {
         return this.openTransaction([storeName], readWrite).then(trans => {
             const store = attempt(() => {
                 return trans.getStore(storeName);

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -68,7 +68,6 @@ export interface DbIndex {
     countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
         : Promise<number>;
     fullTextSearch(searchPhrase: string, resolution?: FullTextTermResolution, limit?: number): Promise<ItemType[]>;
-    removeRange( keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean): Promise<void>;
 }
 
 // Interface type describing a database store opened for accessing.  Get commands at this level work against the primary keypath
@@ -78,6 +77,11 @@ export interface DbStore {
     getMultiple(keyOrKeys: KeyType | KeyType[]): Promise<ItemType[]>;
     put(itemOrItems: ItemType | ItemType[]): Promise<void>;
     remove(keyOrKeys: KeyType | KeyType[]): Promise<void>;
+    removeRange(indexName: string, 
+                keyLowRange: KeyType, 
+                keyHighRange: KeyType, 
+                lowRangeExclusive?: boolean, 
+                highRangeExclusive?: boolean): Promise<void>;
 
     openPrimaryKey(): DbIndex;
     openIndex(indexName: string): DbIndex;
@@ -188,8 +192,8 @@ export abstract class DbProvider {
                 keyHighRange: KeyType,
                 lowRangeExclusive?: boolean,
                 highRangeExclusive?: boolean): Promise<void> {
-      return this._getStoreIndexTransaction(storeName, true, indexName).then( index => {
-        return index.removeRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+      return this._getStoreTransaction(storeName, true).then( store => {
+        return store.removeRange(indexName, keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
       });
     }    
 

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -193,7 +193,7 @@ export abstract class DbProvider {
       });
     }    
 
-    protected _getStoreIndexTransaction(storeName: string, readWrite: boolean, indexName: string | undefined): Promise<DbIndex> {
+    private _getStoreIndexTransaction(storeName: string, readWrite: boolean, indexName: string | undefined): Promise<DbIndex> {
         return this._getStoreTransaction(storeName, readWrite).then(store => {
             const index = attempt(() => {
                 return indexName ? store.openIndex(indexName) : store.openPrimaryKey();

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -150,7 +150,7 @@ export abstract class DbProvider {
 
     protected abstract _deleteDatabaseInternal(): Promise<void>;
 
-    protected _getStoreTransaction(storeName: string, readWrite: boolean): Promise<DbStore> {
+    private _getStoreTransaction(storeName: string, readWrite: boolean): Promise<DbStore> {
         return this.openTransaction([storeName], readWrite).then(trans => {
             const store = attempt(() => {
                 return trans.getStore(storeName);

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -33,7 +33,7 @@ function sleep(timeMs: number): Promise<void> {
 }
 
 describe('NoSqlProvider', function () {
-    this.timeout(60*1000);
+    this.timeout(60 * 1000);
     after(done => {
         if (cleanupFile) {
             var fs = require('fs');
@@ -485,7 +485,7 @@ describe('NoSqlProvider', function () {
                                 });
                             });
                         });
-                    }).then(() => done(), (err) => done(err));;
+                    }).then(() => done(), (err) => done(err));
                 });
 
                 it('Remove range', (done) => {

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -488,6 +488,68 @@ describe('NoSqlProvider', function () {
                     }).then(() => done(), (err) => done(err));;
                 });
 
+                it('Remove range', (done) => {
+                    return openProvider(provName, {
+                        version: 1,
+                        stores: [
+                            {
+                                name: 'test',
+                                primaryKeyPath: 'id'
+                            }
+                        ]
+                    }, true).then(prov => {
+                        return prov.put('test', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i => { return { id: 'a' + i }; })).then(() => {
+                            return prov.getAll('test', undefined).then(rets => {
+                                assert(!!rets);
+                                assert.equal(rets.length, 10);
+                                // Test removing low/high inclusive range
+                                return prov.removeRange('test', '', 'a4', 'a6').then(() => {
+                                    return prov.getAll('test', undefined).then(retVals => {
+                                        const rets = retVals as TestObj[];
+                                        assert(!!rets);
+                                        assert.equal(rets.length, 7);
+                                        assert.equal(rets[0].id, 'a1');
+                                        assert.equal(rets[1].id, 'a10');
+                                        assert.equal(rets[2].id, 'a2');
+                                        assert.equal(rets[3].id, 'a3');
+                                        assert.equal(rets[4].id, 'a7');
+                                        assert.equal(rets[5].id, 'a8');
+                                        assert.equal(rets[6].id, 'a9');
+                                        return Promise.resolve().then(() => {
+                                            // Test removing low exclusive, high inclusive
+                                            return prov.removeRange('test', '', 'a7', 'a9', true, false).then(() => {
+                                                return prov.getAll('test', undefined).then(retVals => {
+                                                    const rets = retVals as TestObj[];
+                                                    assert(!!rets);
+                                                    assert.equal(rets.length, 5);
+                                                    assert.equal(rets[0].id, 'a1');
+                                                    assert.equal(rets[1].id, 'a10');        
+                                                    assert.equal(rets[2].id, 'a2');
+                                                    assert.equal(rets[3].id, 'a3');
+                                                    assert.equal(rets[4].id, 'a7');
+                                                    return Promise.resolve().then(() => {
+                                                        // Test removing low inclusive, high exclusive
+                                                        return prov.removeRange('test', '', 'a1', 'a3', false, true).then(() => {
+                                                            return prov.getAll('test', undefined).then(retVals => {
+                                                                const rets = retVals as TestObj[];
+                                                                assert(!!rets);
+                                                                assert.equal(rets.length, 2);
+                                                                assert.equal(rets[0].id, 'a3');
+                                                                assert.equal(rets[1].id, 'a7');
+                                                                return prov.close();
+                                                            });
+                                                        });
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    }).then(() => done(), (err) => done(err));
+                });                
+
                 it('Invalid Key Type', (done) => {
                     return openProvider(provName, {
                         version: 1,

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -488,7 +488,7 @@ describe('NoSqlProvider', function () {
                     }).then(() => done(), (err) => done(err));
                 });
 
-                it('Remove range', (done) => {
+                it('Remove range (inclusive low/high)', (done) => {
                     return openProvider(provName, {
                         version: 1,
                         stores: [
@@ -502,8 +502,105 @@ describe('NoSqlProvider', function () {
                             return prov.getAll('test', undefined).then(rets => {
                                 assert(!!rets);
                                 assert.equal(rets.length, 10);
-                                // Test removing low/high inclusive range
-                                return prov.removeRange('test', '', 'a4', 'a6').then(() => {
+                                return prov.removeRange('test', '', 'a3', 'a7').then(() => {
+                                    return prov.getAll('test', undefined).then(retVals => {
+                                        const rets = retVals as TestObj[];
+                                        assert(!!rets);
+                                        assert.equal(rets.length, 5);
+                                        assert.equal(rets[0].id, 'a1');
+                                        assert.equal(rets[1].id, 'a10');
+                                        assert.equal(rets[2].id, 'a2');
+                                        assert.equal(rets[3].id, 'a8');
+                                        assert.equal(rets[4].id, 'a9');
+                                        return  prov.close();
+                                    });
+                                });
+                            });
+                        });
+                    }).then(() => done(), (err) => done(err));
+                });                
+
+                it('Remove range (exclusive low, inclusive high)', (done) => {
+                    return openProvider(provName, {
+                        version: 1,
+                        stores: [
+                            {
+                                name: 'test',
+                                primaryKeyPath: 'id'
+                            }
+                        ]
+                    }, true).then(prov => {
+                        return prov.put('test', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i => { return { id: 'a' + i }; })).then(() => {
+                            return prov.getAll('test', undefined).then(rets => {
+                                assert(!!rets);
+                                assert.equal(rets.length, 10);
+                                return prov.removeRange('test', '', 'a3', 'a7', true, false).then(() => {
+                                    return prov.getAll('test', undefined).then(retVals => {
+                                        const rets = retVals as TestObj[];
+                                        assert(!!rets);
+                                        assert.equal(rets.length, 6);
+                                        assert.equal(rets[0].id, 'a1');
+                                        assert.equal(rets[1].id, 'a10');
+                                        assert.equal(rets[2].id, 'a2');
+                                        assert.equal(rets[3].id, 'a3');
+                                        assert.equal(rets[4].id, 'a8');
+                                        assert.equal(rets[5].id, 'a9');
+                                        return prov.close();
+                                    });
+                                });
+                            });
+                        });
+                    }).then(() => done(), (err) => done(err));
+                });
+
+                it('Remove range (inclusive low, exclusive high)', (done) => {
+                    return openProvider(provName, {
+                        version: 1,
+                        stores: [
+                            {
+                                name: 'test',
+                                primaryKeyPath: 'id'
+                            }
+                        ]
+                    }, true).then(prov => {
+                        return prov.put('test', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i => { return { id: 'a' + i }; })).then(() => {
+                            return prov.getAll('test', undefined).then(rets => {
+                                assert(!!rets);
+                                assert.equal(rets.length, 10);
+                                return prov.removeRange('test', '', 'a3', 'a7', false, true).then(() => {
+                                    return prov.getAll('test', undefined).then(retVals => {
+                                        const rets = retVals as TestObj[];
+                                        assert(!!rets);
+                                        assert.equal(rets.length, 6);
+                                        assert.equal(rets[0].id, 'a1');
+                                        assert.equal(rets[1].id, 'a10');
+                                        assert.equal(rets[2].id, 'a2');
+                                        assert.equal(rets[3].id, 'a7');
+                                        assert.equal(rets[4].id, 'a8');
+                                        assert.equal(rets[5].id, 'a9');
+                                        return prov.close();
+                                    });
+                                });
+                            });
+                        });
+                    }).then(() => done(), (err) => done(err));
+                });
+
+                it('Remove range (exclusive low, exclusive high)', (done) => {
+                    return openProvider(provName, {
+                        version: 1,
+                        stores: [
+                            {
+                                name: 'test',
+                                primaryKeyPath: 'id'
+                            }
+                        ]
+                    }, true).then(prov => {
+                        return prov.put('test', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i => { return { id: 'a' + i }; })).then(() => {
+                            return prov.getAll('test', undefined).then(rets => {
+                                assert(!!rets);
+                                assert.equal(rets.length, 10);
+                                return prov.removeRange('test', '', 'a3', 'a7', true, true).then(() => {
                                     return prov.getAll('test', undefined).then(retVals => {
                                         const rets = retVals as TestObj[];
                                         assert(!!rets);
@@ -515,40 +612,72 @@ describe('NoSqlProvider', function () {
                                         assert.equal(rets[4].id, 'a7');
                                         assert.equal(rets[5].id, 'a8');
                                         assert.equal(rets[6].id, 'a9');
-                                        return Promise.resolve().then(() => {
-                                            // Test removing low exclusive, high inclusive
-                                            return prov.removeRange('test', '', 'a7', 'a9', true, false).then(() => {
-                                                return prov.getAll('test', undefined).then(retVals => {
-                                                    const rets = retVals as TestObj[];
-                                                    assert(!!rets);
-                                                    assert.equal(rets.length, 5);
-                                                    assert.equal(rets[0].id, 'a1');
-                                                    assert.equal(rets[1].id, 'a10');        
-                                                    assert.equal(rets[2].id, 'a2');
-                                                    assert.equal(rets[3].id, 'a3');
-                                                    assert.equal(rets[4].id, 'a7');
-                                                    return Promise.resolve().then(() => {
-                                                        // Test removing low inclusive, high exclusive
-                                                        return prov.removeRange('test', '', 'a1', 'a3', false, true).then(() => {
-                                                            return prov.getAll('test', undefined).then(retVals => {
-                                                                const rets = retVals as TestObj[];
-                                                                assert(!!rets);
-                                                                assert.equal(rets.length, 2);
-                                                                assert.equal(rets[0].id, 'a3');
-                                                                assert.equal(rets[1].id, 'a7');
-                                                                return prov.close();
-                                                            });
-                                                        });
-                                                    });
-                                                });
-                                            });
-                                        });
+                                        return prov.close();
                                     });
                                 });
                             });
                         });
                     }).then(() => done(), (err) => done(err));
-                });                
+                });     
+                
+                it('Remove range (nothing done)', (done) => {
+                    return openProvider(provName, {
+                        version: 1,
+                        stores: [
+                            {
+                                name: 'test',
+                                primaryKeyPath: 'id'
+                            }
+                        ]
+                    }, true).then(prov => {
+                        return prov.put('test', [1, 2, 3, 4, 5].map(i => { return { id: 'a' + i }; })).then(() => {
+                            return prov.getAll('test', undefined).then(rets => {
+                                assert(!!rets);
+                                assert.equal(rets.length, 5);
+                                return prov.removeRange('test', '', 'a6', 'a9').then(() => {
+                                    return prov.getAll('test', undefined).then(retVals => {
+                                        const rets = retVals as TestObj[];
+                                        assert(!!rets);
+                                        assert.equal(rets.length, 5);
+                                        assert.equal(rets[0].id, 'a1');
+                                        assert.equal(rets[1].id, 'a2');
+                                        assert.equal(rets[2].id, 'a3');
+                                        assert.equal(rets[3].id, 'a4');
+                                        assert.equal(rets[4].id, 'a5');
+                                        return prov.close();
+                                    });
+                                });
+                            });
+                        });
+                    }).then(() => done(), (err) => done(err));
+                });   
+                
+                it('Remove range (all removed)', (done) => {
+                    return openProvider(provName, {
+                        version: 1,
+                        stores: [
+                            {
+                                name: 'test',
+                                primaryKeyPath: 'id'
+                            }
+                        ]
+                    }, true).then(prov => {
+                        return prov.put('test', [1, 2, 3, 4, 5].map(i => { return { id: 'a' + i }; })).then(() => {
+                            return prov.getAll('test', undefined).then(rets => {
+                                assert(!!rets);
+                                assert.equal(rets.length, 5);
+                                return prov.removeRange('test', '', 'a1', 'a5').then(() => {
+                                    return prov.getAll('test', undefined).then(retVals => {
+                                        const rets = retVals as TestObj[];
+                                        assert(!!rets);
+                                        assert.equal(rets.length, 0);
+                                        return prov.close();
+                                    });
+                                });
+                            });
+                        });
+                    }).then(() => done(), (err) => done(err));
+                });                          
 
                 it('Invalid Key Type', (done) => {
                     return openProvider(provName, {

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -33,7 +33,7 @@ function sleep(timeMs: number): Promise<void> {
 }
 
 describe('NoSqlProvider', function () {
-    this.timeout(5*60*1000);
+    this.timeout(5 * 60 * 1000);
     after(done => {
         if (cleanupFile) {
             var fs = require('fs');
@@ -413,7 +413,7 @@ describe('NoSqlProvider', function () {
                             });
                         });
                     }).finally(() => {
-                        done()
+                        done();
                     });
                 });
 


### PR DESCRIPTION
This change adds a removeRange API to DbProvider. This allows removal of items by specifying a low/high range, similar to the arguments of the getRange() API.