### PR TITLE
Fix transpiler issues with unused variables.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sqlite3": "^4.0.2",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "3.1.1",
+    "typescript": "3.3.1",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.1"
   },

--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -28,7 +28,7 @@ export function breakAndNormalizeSearchPhrase(phrase: string): string[] {
     // Deburr and tolower before using words since words breaks on CaseChanges.
     const wordInPhrase = words(deburr(phrase).toLowerCase(), _whitespaceRegexMatch);
     // map(mapKeys is faster than uniq since it's just a pile of strings.
-    const uniqueWordas = map(mapKeys(wordInPhrase), (value, key) => sqlCompat(key));
+    const uniqueWordas = map(mapKeys(wordInPhrase), (_value, key) => sqlCompat(key));
     return filter(uniqueWordas, word => !!lodashTrim(word));
 }
 
@@ -80,7 +80,7 @@ export abstract class DbIndexFTSFromRangeQueries implements DbIndex {
 
             if (resolution === FullTextTermResolution.And) {
                 const [first, ...others] = uniquers;
-                const dic = pickBy(first, (value, key) => every(others, set => key in set)) as Dictionary<ItemType>;
+                const dic = pickBy(first, (_value, key) => every(others, set => key in set)) as Dictionary<ItemType>;
                 const data = values(dic);
                 if (limit) {
                     return take(data, limit);

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -263,7 +263,7 @@ class InMemoryStore implements DbStore {
             return Promise.reject<void>('InMemoryTransaction already closed');
         }
         this._checkDataClone();
-        each(this._mergedData, (val, key) => {
+        each(this._mergedData, (_val, key) => {
             this._pendingCommitDataChanges!!![key] = undefined;
         });
         this._mergedData = {};

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -111,7 +111,7 @@ export abstract class DbProvider {
     protected _schema: DbSchema | undefined;
     protected _verbose: boolean | undefined;
 
-    open(dbName: string, schema: DbSchema, wipeIfExists: boolean, verbose: boolean): Promise<void> {
+    open(dbName: string, schema: DbSchema, _wipeIfExists: boolean, verbose: boolean): Promise<void> {
         // virtual call
         this._dbName = dbName;
         this._schema = schema;
@@ -252,7 +252,7 @@ export abstract class DbProvider {
     }
 
     fullTextSearch(storeName: string, indexName: string, searchPhrase: string,
-        resolution: FullTextTermResolution = FullTextTermResolution.And, limit?: number): Promise<ItemType[]> {
+        resolution: FullTextTermResolution = FullTextTermResolution.And, _limit?: number): Promise<ItemType[]> {
         return this._getStoreIndexTransaction(storeName, false, indexName).then(index => {
             return index.fullTextSearch(searchPhrase, resolution);
         });

--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -4,13 +4,13 @@ declare interface Promise<T> {
 }
 
 Promise.prototype.finally = function (onResolveOrReject) {
-    return this.catch(function (reason) {
+    return this.catch(function (reason: any) {
         return reason;
     }).then(onResolveOrReject);
 };
 Promise.prototype.always = function (onResolveOrReject) {
     return this.then(onResolveOrReject,
-        function (reason) {
+        function (reason: any) {
             onResolveOrReject(reason);
             throw reason;
         });

--- a/src/StoreHelpers.ts
+++ b/src/StoreHelpers.ts
@@ -67,7 +67,7 @@ export class SimpleTransactionIndexHelper<ObjectType extends ItemType, IndexKeyF
 }
 
 export class SimpleTransactionStoreHelper<StoreName extends string, ObjectType extends ItemType, KeyFormat extends KeyType> {
-    constructor(protected _store: DbStore, storeName /* Force type-checking */: DBStore<StoreName, ObjectType, KeyFormat>) {
+    constructor(protected _store: DbStore, _storeName /* Force type-checking */: DBStore<StoreName, ObjectType, KeyFormat>) {
         // Nothing to see here
     }
 

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -185,7 +185,7 @@ describe('NoSqlProvider', function () {
                         return prov.put('test', obj);
                     });
 
-                    return Promise.all(putters).then(rets => {
+                    return Promise.all(putters).then(() => {
                         let formIndex = (i: number, i2: number = i): string | string[] => {
                             if (compound) {
                                 return ['indexa' + i, 'indexb' + i2];
@@ -691,7 +691,7 @@ describe('NoSqlProvider', function () {
                     }, true).then(prov => {
                         return prov.put('test', { id: { x: 'a' }, val: 'b' }).then(() => {
                             assert(false, 'Shouldn\'t get here');
-                        }, (err) => {
+                        }, () => {
                             // Woot, failed like it's supposed to
                             return prov.close();
                         }).then(() => {
@@ -1052,7 +1052,7 @@ describe('NoSqlProvider', function () {
                                 let check1 = false;
                                 promise.then(() => {
                                     check1 = true;
-                                }, err => {
+                                }, () => {
                                     assert.ok(false, 'Bad');
                                 });
                                 return sleep(200).then(() => {
@@ -1063,7 +1063,7 @@ describe('NoSqlProvider', function () {
                             }).then(() => {
                                 assert.ok(false, 'Should fail');
                                 return Promise.reject<void>();
-                            }, err => {
+                            }, () => {
                                 // woot
                                 return undefined;
                             }).then(() => {
@@ -1090,7 +1090,7 @@ describe('NoSqlProvider', function () {
                                     trans.abort();
                                     return promise.then(() => {
                                         assert.ok(false, 'Should fail');
-                                    }, err => {
+                                    }, () => {
                                         return prov.get('test', 'abc').then(res => {
                                             assert.ok(!res);
                                             checked = true;
@@ -1178,7 +1178,7 @@ describe('NoSqlProvider', function () {
                                     }
                                 ]
                             }, false).then(prov => {
-                                return prov.get('test', 'abc').then(item => {
+                                return prov.get('test', 'abc').then(() => {
                                     return prov.close().then(() => {
                                         return Promise.reject<void>('Shouldn\'t have worked');
                                     });
@@ -1296,7 +1296,7 @@ describe('NoSqlProvider', function () {
                                     }
                                 ]
                             }, false).then(prov => {
-                                return prov.get('test', 'abc').then(item => {
+                                return prov.get('test', 'abc').then(() => {
                                     return prov.close().then(() => {
                                         return Promise.reject<void>('Shouldn\'t have worked');
                                     });
@@ -1335,7 +1335,7 @@ describe('NoSqlProvider', function () {
                                     }
                                 ]
                             }, false).then(prov => {
-                                return prov.get('test', 'abc').then(item => {
+                                return prov.get('test', 'abc').then(() => {
                                     return prov.close().then(() => {
                                         return Promise.reject<void>('Shouldn\'t have worked');
                                     });
@@ -1394,7 +1394,7 @@ describe('NoSqlProvider', function () {
                         }).then(() => done(), (err) => done(err));
                     });
 
-                    function testBatchUpgrade(expectedCallCount: number, itemByteSize: number): Promise<void> {
+                    function testBatchUpgrade(itemByteSize: number): Promise<void> {
                         const recordCount = 5000;
                         const data: { [id: string]: { id: string, tt: string } } = {};
                         times(recordCount, num => {
@@ -1447,11 +1447,11 @@ describe('NoSqlProvider', function () {
                     }
 
                     it('Add index - Large records - batched upgrade', (done) => {
-                        return testBatchUpgrade(51, 10000).then(() => done(), (err) => done(err));
+                        return testBatchUpgrade(10000).then(() => done(), (err) => done(err));
                     });
 
                     it('Add index - small records - No batch upgrade', (done) => {
-                        return testBatchUpgrade(1, 1).then(() => done(), (err) => done(err));
+                        return testBatchUpgrade(1).then(() => done(), (err) => done(err));
                     });
 
                     if (provName.indexOf('indexeddb') !== 0) {
@@ -1485,7 +1485,7 @@ describe('NoSqlProvider', function () {
                                     ]
                                 }, false).then(() => {
                                     return Promise.reject('Should not work');
-                                }, err => {
+                                }, () => {
                                     return Promise.resolve();
                                 });
                             }).then(() => done(), (err) => done(err));
@@ -1627,7 +1627,7 @@ describe('NoSqlProvider', function () {
                                     }
                                 ]
                             }, false).then(prov => {
-                                return prov.getOnly('test', 'ind1', 'a').then(items => {
+                                return prov.getOnly('test', 'ind1', 'a').then(() => {
                                     return prov.close().then(() => {
                                         return Promise.reject<void>('Shouldn\'t have worked');
                                     });
@@ -2047,7 +2047,7 @@ describe('NoSqlProvider', function () {
                                     assert.equal(items[0].id, 'abc');
                                 }).then(() => {
                                     assert.ok(false, 'should not work');
-                                }, err => {
+                                }, () => {
                                     return Promise.resolve();
                                 });
                                 return Promise.all([p1, p2]).then(() => {
@@ -2351,7 +2351,7 @@ describe('NoSqlProvider', function () {
                                             assert.equal(items[0].id, 'abc');
                                         }).then(() => {
                                             assert.ok(false, 'should not work');
-                                        }, err => {
+                                        }, () => {
                                             return Promise.resolve();
                                         });
                                         return Promise.all([p1, p2]).then(() => {
@@ -2403,7 +2403,7 @@ describe('NoSqlProvider', function () {
                                                 assert.equal(items[0].tt, 'a');
                                                 assert.equal(items[0].zz, 'aa');
                                             });
-                                            const p2 = prov.getOnly('test', 'ind1', 'a').then(items => {
+                                            const p2 = prov.getOnly('test', 'ind1', 'a').then(() => {
                                                 return Promise.reject<void>('Shouldn\'t have worked');
                                             }, () => {
                                                 // Expected to fail, so chain from failure to success

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "strictPropertyInitialization": true,
+        "strictNullChecks": true,        
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "sourceMap": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,9 +2856,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
+typescript@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
With newer Typescript transpiler, some unused variables were showing up as transpile errors. This change is to address these errors.